### PR TITLE
Fix wheel picker re-render issue

### DIFF
--- a/src/components/WheelPicker/WheelPicker.tsx
+++ b/src/components/WheelPicker/WheelPicker.tsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useEffect,
+} from 'react';
 import { Animated, View } from 'react-native';
 import Constants from '../../constants';
 import { useWheelPicker } from '../../hooks';
@@ -77,6 +82,13 @@ const WheelPicker = forwardRef<WheelPickerRef, WheelPickerProps>(
         onChangeValue(index ?? 0, originalValue?.toString() ?? '');
       },
     }));
+
+    useEffect(() => {
+      flatListRef.current?.scrollToIndex({
+        index: initialScrollIndex,
+        animated: false,
+      });
+    }, [initialScrollIndex]);
 
     const renderItem = useCallback(
       ({ item, index }: { item: string | null; index: number }) => (


### PR DESCRIPTION
## Summary
- ensure wheel picker scrolls to initial index when mounted

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868ed6204588333b5275bfcf5ab888a