### PR TITLE
Fix blank wheel picker after remount

### DIFF
--- a/src/hooks/useWheelPicker.ts
+++ b/src/hooks/useWheelPicker.ts
@@ -60,8 +60,15 @@ const useWheelPicker = ({
   const [arrayData, setArrayData] = useState<Array<string | number>>([
     ...loopedData,
   ]);
+  const initialIndex = useMemo(
+    () =>
+      !infiniteScroll
+        ? initialSelectedIndex ?? 0
+        : loopedData.length / 2 + initialSelectedIndex,
+    [infiniteScroll, initialSelectedIndex, loopedData.length]
+  );
   const flatListRef = useRef<FlatList<string | null>>(null);
-  const [scrollY] = useState(new Animated.Value(0));
+  const scrollY = useRef(new Animated.Value(initialIndex * elementHeight)).current;
 
   /**
    * Verify if the props are valid or not
@@ -175,10 +182,8 @@ const useWheelPicker = ({
    * Here 0 is initially selected 0 index if infiniteScroll is false
    */
   const initialScrollIndex = useMemo(() => {
-    return !infiniteScroll
-      ? initialSelectedIndex ?? 0
-      : arrayData?.length / 2 + initialSelectedIndex;
-  }, [arrayData, initialSelectedIndex, infiniteScroll]);
+    return initialIndex;
+  }, [initialIndex]);
 
   /**
    * Set the initial selected value


### PR DESCRIPTION
## Summary
- preserve scroll offset for the list when the picker is mounted

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ed6204588333b5275bfcf5ab888a